### PR TITLE
docco task

### DIFF
--- a/tasks/docco.js
+++ b/tasks/docco.js
@@ -1,0 +1,18 @@
+var docco = require('docco');
+
+module.exports = function (grunt) {
+	grunt.registerMultiTask('docco', 'Docco processor', function () {
+		var _ = grunt.util._;
+		var done = this.async();
+		var src = [];
+
+		if (_.isArray(this.data.src)) {
+			this.data.src.forEach(function (srcString) {
+				src = grunt.file.expand(srcString);
+			})
+		} else {
+			grunt.file.expand(this.data.src);
+		}
+		docco.document(_.extend({args: src},this.options()));
+	});
+}


### PR DESCRIPTION
allows a grunt task of "docco". accepts configuration in the format of the following:

```
docco: {
            dist : {
                src: ['dist/*.js'],
                options: {
                    output: 'dist/docs'
                }
            }
        }
```
