### PR TITLE
Testify generates files that puts IE < 10 into quirks mode

### DIFF
--- a/tasks/testify.js
+++ b/tasks/testify.js
@@ -40,10 +40,9 @@ module.exports = function(grunt) {
 				_.extend(options, transform.options.call(config, configurationName));
 			}
 
-			var lib = '<!-- AUTO GENERATED - DO NOT MODIFY -->\n'+
-				beautify.html(ejs.render(template, options), {
+			var lib = beautify.html(ejs.render(template, options), {
 					"wrap_line_length": 70
-				});
+				}).replace('<html>', '<!-- AUTO GENERATED - DO NOT MODIFY -->\n<html>');
 
 			grunt.log.writeln('Generating ' + data.out + configurationName + '.html');
 			grunt.file.write(data.out + configurationName + '.html', lib);


### PR DESCRIPTION
If a valid DOCTYPE is defined in the provided template, the comment added to the beginning of the HTML file will put IE < 10 into quirks mode which will wreak havoc on tests.

This change adds the comment above the `<html>` tag which will be below the DOCTYPE declaration.
